### PR TITLE
Http client can to return null in Connection class

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -178,7 +178,7 @@ class Connection extends Component
     /**
      * @return Client
      */
-    public function getClient(): Client
+    public function getClient(): ?Client
     {
         return $this->client;
     }


### PR DESCRIPTION
Return value of raoptimus\openstack\Connection::getClient() must be an instance of GuzzleHttp\Client, null returned